### PR TITLE
Create MineablePatches.xml

### DIFF
--- a/MiningCo. MMS/MMS/MiningCo. MMS/1.2/Patches/MineablePatches.xml
+++ b/MiningCo. MMS/MMS/MiningCo. MMS/1.2/Patches/MineablePatches.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <!--Metals+ Ores-->
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+           <li>MiningCo. MMS</li>
+           <li>Metals+</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <success>Always</success>
+            <operations>
+                <li Class="PatchOperationAdd">
+                <xpath>/Defs/ThingDef[defName="MobileMineralSonar"]/scannedThingDefs</xpath>
+                <value>
+                    <li>MineableCopper</li>
+                    <li>MineableTin</li>
+                    <li>MineableIron</li>
+                    <li>MineableTitanium</li>
+                </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+    <!--MorrowRim Ebony and Glass-->
+    <Operation Class="PatchOperationFindMod">
+        <mods>
+           <li>MiningCo. MMS</li>
+           <li>MorrowRim - Glass and Ebony</li>
+        </mods>
+        <match Class="PatchOperationSequence">
+            <success>Always</success>
+            <operations>
+                <li Class="PatchOperationAdd">
+                <xpath>/Defs/ThingDef[defName="MobileMineralSonar"]/scannedThingDefs</xpath>
+                <value>
+                    <li>MorrowRim_MineableGlass</li>
+                    <li>MorrowRim_MineableEbony</li>
+                </value>
+                </li>
+            </operations>
+        </match>
+    </Operation>
+</Patch>


### PR DESCRIPTION
Add patches for Metals+ and some MorrowRim mineable ores. 

https://steamcommunity.com/sharedfiles/filedetails/?id=1554804570

https://steamcommunity.com/sharedfiles/filedetails/?id=2053604662

There's probably a way to finds ores automatically by searching for `<isResourceRock>true</isResourceRock>` or something similar in the TerrainDefs, but I think it would require C#, and that's a bit beyond my ability atm.